### PR TITLE
Compile fix for Windows

### DIFF
--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -17,6 +17,12 @@
 #include <vector>
 //
 
+// Fix compiling under Windows
+#if defined(CONF_FAMILY_WINDOWS)
+	#define _USE_MATH_DEFINES
+	#include <math.h>
+#endif
+//
 
 class CTuneParam
 {


### PR DESCRIPTION
adding
#if defined(CONF_FAMILY_WINDOWS)
	#define _USE_MATH_DEFINES
	#include <math.h>
#endif

// sorry for the line endings (going to change this in future)